### PR TITLE
115-add-error-handling (resolves #115)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,6 +39,7 @@
         "@types/react": "^17.0.38",
         "@types/react-dom": "^17.0.11",
         "@types/styled-components": "^5.1.20",
+        "@types/validator": "^13.7.5",
         "typescript": "^4.5.4"
       }
     },
@@ -10630,6 +10631,12 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+    },
+    "node_modules/@types/validator": {
+      "version": "13.7.5",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.5.tgz",
+      "integrity": "sha512-9rQHeAqz6Jw3gDhttkmWetoriW5FPbxylv/6h6mXtaj2NKRcOvOmvfcswVdLVpbuy10NrO486K3lCoLgoIhiIA==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -37874,6 +37881,12 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+    },
+    "@types/validator": {
+      "version": "13.7.5",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.5.tgz",
+      "integrity": "sha512-9rQHeAqz6Jw3gDhttkmWetoriW5FPbxylv/6h6mXtaj2NKRcOvOmvfcswVdLVpbuy10NrO486K3lCoLgoIhiIA==",
+      "dev": true
     },
     "@types/ws": {
       "version": "8.5.3",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "react-step-progress-bar": "^1.0.3",
         "styled-components": "^5.3.3",
         "uuidv4": "^6.2.13",
+        "validator": "^13.7.0",
         "web-vitals": "^2.1.2"
       },
       "devDependencies": {
@@ -28336,6 +28337,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -50961,6 +50970,11 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
       }
+    },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,6 +58,7 @@
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
     "@types/styled-components": "^5.1.20",
+    "@types/validator": "^13.7.5",
     "typescript": "^4.5.4"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "react-step-progress-bar": "^1.0.3",
     "styled-components": "^5.3.3",
     "uuidv4": "^6.2.13",
+    "validator": "^13.7.0",
     "web-vitals": "^2.1.2"
   },
   "scripts": {

--- a/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.css
+++ b/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.css
@@ -102,6 +102,11 @@
     font-weight: 500;
 }
 
+.inputError {
+    text-align: left;
+    color: var(--red);
+}
+
 #signUpButton {
     background: var(--primary);
     border: none;

--- a/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.css
+++ b/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.css
@@ -179,18 +179,12 @@
         margin: 0px 0px 24px 0px;
     }
     
-    #accountTypeBox {
-        margin: 0px 0px 3px 0px;
-    }
     
     #userTypeLabel {
         margin: 0px 0px 0px 0px;
         font-size: 11px;
     }
     
-    .accountLabel {
-        font-size: 10px;
-    }
     
     .userTypeButton {
         margin: 1px 6px 0px 18px; 
@@ -209,7 +203,7 @@
     
         margin: 15px 0px 4px 0px;
     }
-    
+
     .inputBox {
         height: 30px;
         width: 100%;
@@ -236,7 +230,8 @@
     }
 }
 
-@media only screen and (max-width: 700px) {
+
+@media only screen and (min-width: 500px) {
     #createAccountBox {
         width: 405px;
         height: 546px;
@@ -255,19 +250,25 @@
     
     #accountTypeBox {
         margin: 0px 0px 3px 0px;
+        display: flex;
+        justify-content: space-between;
     }
-    
+    .accountLabel {
+        font-size: 10px;
+        display: flex;
+        justify-content: space-around;
+        width: 80%;
+        flex-wrap: wrap;
+        align-items: center;
+    }
+
     #userTypeLabel {
         margin: 0px 0px 0px 0px;
         font-size: 10px;
     }
     
-    .accountLabel {
-        font-size: 10px;
-    }
-    
     .userTypeButton {
-        margin: 1px 6px 0px 18px; 
+        margin: 0px 0px 0px 0px; 
     }
     
     #firstNameBox {
@@ -319,5 +320,13 @@
         margin-top: 50vh;
         transform: translateY(-50%);
         padding: 36px 44px 49px 44px;
+    }
+    #accountTypeBox {
+        margin: 0px 0px 0px 0px;
+        display: flex;
+        justify-content: space-between;
+    }
+    .accountLabel {
+        align-items: center;
     }
 }

--- a/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
+++ b/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
@@ -10,6 +10,7 @@ import IconButton from '@mui/material/IconButton';
 import { v4 as uuidv4 } from 'uuid';
 /* Backend */
 import { addUser, User } from 'api/user';
+import { debug } from "console";
 
 
 
@@ -27,6 +28,14 @@ const CreateAccountPage = (): JSX.Element => {
         showPassword: false
     });
     const [id, setID] = useState<string>(uuidv4());
+    const errorMessagesInitial = {
+        userType: "",
+        name: "",
+        email: "",
+        phoneNumber: "",
+        password: ""
+    };
+    const [errorMessages, setErrorMessages] = useState(errorMessagesInitial);
     let processedPhoneNumber: number; //Phone number converted from string
 
     let navigate = useNavigate();
@@ -118,90 +127,88 @@ const CreateAccountPage = (): JSX.Element => {
         Desc: Validates all the form fields
         Return: boolean (true if all are valid, false if one is not)
         */
-        const valid: boolean =
-            (
-                validateUserType() &&
-                validateName() &&
-                validateEmail() &&
-                validatePhoneNumber() &&
-                processPhoneNumber() &&
-                validatePassword()
-            )
-        return valid;
+        let currentErrors = {};
+        currentErrors = validateUserType() ? {...currentErrors, ...validateUserType()} : currentErrors;
+        currentErrors = validateFirstName() ? {...currentErrors, ...validateFirstName()} : currentErrors;
+        currentErrors = validateLastName() ? {...currentErrors, ...validateLastName()} : currentErrors;
+        currentErrors = validateEmail() ? {...currentErrors, ...validateEmail()} : currentErrors;
+        currentErrors = validatePhoneNumber() ? {...currentErrors, ...validatePhoneNumber()} : currentErrors;
+        currentErrors = validatePassword() ? {...currentErrors, ...validatePassword()} : currentErrors;
+        setErrorMessages({...errorMessagesInitial, ...currentErrors});
+        return Object.keys(currentErrors).length === 0;
     }
 
-    const validateUserType = (): boolean => {
+    const validateUserType = (): null | Object => {
         /*
         Desc: Validates userTypes (donor, volunteer, administrator)
         Return: boolean (true if valid, false if not)
         */
         if (userType === "") {
-            alert("Please select an account type");
-            return false;
+            return {userType: "Please select an account type"};
         }
-        return true;
+        return null;
     }
 
-    const validateName = (): boolean => {
+    const validateFirstName = (): null | Object => {
         /*
-        Desc: Validates firstName and lastName
+        Desc: Validates firstName
         Return: boolean (true if valid, false if not)
         */
-        if (firstName === "" || lastName === "") {
-            alert("Please add your first and last name");
-            return false;
+        //setErrorMessages({...errorMessagesInitial});
+        if (firstName === "" && lastName === "") {
+            return{name: "Please enter your full name"};
+        } else if (firstName === "") {
+            return{name: "Please enter your first name"};
         }
-        return true;
+        return{name: ""};
     }
-
-    const validatePhoneNumber = (): boolean => {
+    const validateLastName = (): null | Object => {
         /*
-        Desc: Validates phone number
+        Desc: Validates lastName
         Return: boolean (true if valid, false if not)
         */
-        if (phoneNumber === "") {
-            alert("Please add a phone number");
-            return false;
+        //setErrorMessages({...errorMessagesInitial});
+        if (firstName === "" && lastName === "") {
+            return{name: "Please enter your full name"};
+        } else if (lastName === "") {
+            return{name: "Please enter your last name"};
         }
-        return true;
+        return{name: ""};
     }
 
-    const validateEmail = (): boolean => {
+
+    const validateEmail = (): null | Object => {
         /*
         Desc: Validates email
         Return: boolean (true if valid, false if not)
         */
         if (email === "") {
-            alert("Please add email");
-            return false;
+            return {email: "Please enter your email"};
         }
         else if (!email.includes("@")) {
-            alert("Please enter a valid email address");
-            return false;
+            return {email: "Please enter a valid email address"};
         }
         //else if (check if email already exists)
         //alert("Account with this email already exists") 
-        return true;
+        return{email: ""};
     }
 
-    const validatePassword = (): boolean => {
+    const validatePassword = (): null | Object => {
         /*
         Desc: Validates password
         Return: boolean (true if valid, false if not)
         */
         const MIN_PASSWORD_LENGTH = 6;
         if (password.value === "") {
-            alert("Please add password");
-            return false;
+            return {password: "Please enter a password"};
         }
         else if (password.value.length < MIN_PASSWORD_LENGTH) {
-            alert(`Please choose a password at least ${MIN_PASSWORD_LENGTH} characters long`);
-            return false;
+            return {password:  `Please choose a password at least ${MIN_PASSWORD_LENGTH} characters long`};
         }
-        return true;
+        return{password: ""};
     }
 
-    function processPhoneNumber(): boolean {
+    function validatePhoneNumber(): null | Object {
         /*
         Desc: Converts phoneNumber string to number. Saves it in global variable processedPhoneNumber
         Return: boolean (true if number successfuly processed, false if not)
@@ -209,8 +216,7 @@ const CreateAccountPage = (): JSX.Element => {
         try {
             const processedString = phoneNumber.replace(/[^0-9]/g, "");
             if (processedString === "") {
-                alert("Please enter your phone number in the form XXX-XXX-XXXX")
-                return false;
+                return { phoneNumber: "Please enter your phone number in the form XXX-XXX-XXXX"};
             }
             // processedPhoneNumber = parseInt(processedString);
             setPhoneNumber(processedString);
@@ -218,10 +224,13 @@ const CreateAccountPage = (): JSX.Element => {
         }
         catch (error) {
             console.error(error);
-            alert("Sorry there was an error processing your phone number. Please enter it in the form XXX-XXX-XXXX");
-            return false;
+            return {phoneNumber: "Sorry there was an error processing your phone number. Please enter it in the form XXX-XXX-XXXX"};
         }
-        return true;
+        return{phoneNumber: ""};
+    }
+
+    function checkError(type: string) {
+        validateForm();
     }
 
     //HTML Body
@@ -254,32 +263,43 @@ const CreateAccountPage = (): JSX.Element => {
                                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => setUserType(e.target.value)} />administrator
                         </div>
                     </div>
-
+                    <div className="inputError">{errorMessages.userType}</div>
 
                     <div id="nameBox">
                         <div className="labelInputBox" id="firstNameBox">
                             <p className="formLabel">First Name</p>
                             <input className="inputBox"
                                 type="text"
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setFirstName(e.target.value)}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    setFirstName(e.target.value);
+                                    setErrorMessages({...errorMessages, ...validateFirstName()});
+                                }}
                             />
                         </div>
                         <div className="labelInputBox" id="lastNameBox">
                             <p className="formLabel">Last Name</p>
                             <input className="inputBox"
                                 type="text"
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setLastName(e.target.value)}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    setLastName(e.target.value);
+                                    setErrorMessages({...errorMessages, ...validateLastName()});
+                                }}
                             />
                         </div>
                     </div>
+                    <div className="inputError">{errorMessages.name}</div>
 
                     <div className="labelInputBox">
                         <p className="formLabel">Email</p>
                         <input className="inputBox"
                             type="text"
                             autoComplete="email"
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+                            onInput={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                setEmail(e.target.value);
+                                setErrorMessages({...errorMessages, ...validateEmail()});
+                            }}
                         />
+                        <div className="inputError">{errorMessages.email}</div>
                     </div>
 
                     <div className="labelInputBox">
@@ -287,8 +307,12 @@ const CreateAccountPage = (): JSX.Element => {
                         <input className="inputBox"
                             type="text"
                             autoComplete="phone"
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPhoneNumber(e.target.value)}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                setPhoneNumber(e.target.value);
+                                setErrorMessages({...errorMessages, ...validatePhoneNumber()});
+                            }}
                         />
+                        <div className="inputError">{errorMessages.phoneNumber}</div>
                     </div>
 
                     <div className="labelInputBox">
@@ -298,7 +322,10 @@ const CreateAccountPage = (): JSX.Element => {
                             value={password.value}
                             type={password.showPassword ? "text" : "password"}
                             disableUnderline={true}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword({ ...password, "value": e.target.value })}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                setPassword({ ...password, "value": e.target.value });
+                                setErrorMessages({...errorMessages, ...validatePassword()});
+                            }}
                             endAdornment={
                                 <InputAdornment position="end">
                                     <IconButton
@@ -310,6 +337,7 @@ const CreateAccountPage = (): JSX.Element => {
                                 </InputAdornment>
                             }
                         />
+                        <div className="inputError">{errorMessages.password}</div>
                     </div>
 
                 </form>

--- a/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
+++ b/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
@@ -28,14 +28,13 @@ const CreateAccountPage = (): JSX.Element => {
         showPassword: false
     });
     const [id, setID] = useState<string>(uuidv4());
-    const errorMessagesInitial = {
-        userType: "",
-        name: "",
-        email: "",
-        phoneNumber: "",
-        password: ""
-    };
-    const [errorMessages, setErrorMessages] = useState(errorMessagesInitial);
+
+    //error messages
+    const [userTypeError, setUserTypeError] = useState<string>("");
+    const [nameError, setNameError] = useState<string>("");
+    const [emailError, setEmailError] = useState<string>("");
+    const [phoneNumberError, setPhoneNumberError] = useState<string>("");
+    const [passwordError, setPasswordError] = useState<string>("");
     let processedPhoneNumber: number; //Phone number converted from string
 
     let navigate = useNavigate();
@@ -127,90 +126,124 @@ const CreateAccountPage = (): JSX.Element => {
         Desc: Validates all the form fields
         Return: boolean (true if all are valid, false if one is not)
         */
-        let currentErrors = {};
-        currentErrors = validateUserType() ? {...currentErrors, ...validateUserType()} : currentErrors;
-        currentErrors = validateName() ? {...currentErrors, ...validateName()} : currentErrors;
-        currentErrors = validateEmail() ? {...currentErrors, ...validateEmail()} : currentErrors;
-        currentErrors = validatePhoneNumber() ? {...currentErrors, ...validatePhoneNumber()} : currentErrors;
-        currentErrors = processPhoneNumber() ? {...currentErrors, ...processPhoneNumber()} : currentErrors;
-        currentErrors = validatePassword() ? {...currentErrors, ...validatePassword()} : currentErrors;
-        setErrorMessages({...errorMessagesInitial, ...currentErrors});
-        return Object.keys(currentErrors).length === 0;
+        let valid: boolean = validateUserType(userType);
+        valid = validateName(firstName, lastName) && valid;
+        valid = validateEmail(email) && valid;
+        valid = validatePhoneNumber(phoneNumber) && valid;
+        valid = validatePassword(password) && valid;
+        return valid;
     }
 
-    const validateUserType = (): null | Object => {
+    const validateUserType = (userType: string): boolean => {
         /*
         Desc: Validates userTypes (donor, volunteer, administrator)
         Return: boolean (true if valid, false if not)
         */
         if (userType === "") {
-            return {userType: "Please select an account type"};
+            setUserTypeError("Please select an account type");
+            return false;
         }
-        return null;
+        setUserTypeError("");
+        return true;
     }
 
-    const validateName = (): null | Object => {
+    const validateName = (firstName: string, lastName: string): boolean => {
         /*
         Desc: Validates firstName and lastName
         Return: boolean (true if valid, false if not)
         */
         //setErrorMessages({...errorMessagesInitial});
-        
-        if (firstName === "" && lastName === "") {
-            return{name: "Please enter your full name"};
-        } else if (firstName === "") {
-            return{name: "Please enter your first name"};
-        } else if (lastName === "") {
-            return{name: "Please enter your last name"};
+        debugger;
+        if (validateFirstName(firstName) && validateLastName(lastName)) {
+            return true;
+        } else if (!validateFirstName(firstName) && !validateLastName(lastName)) {
+            setNameError("Please enter your full name");
         }
-        return null;
+        return false;
+    }
+    const validateFirstName = (firstName: string): boolean => {
+        /*
+        Desc: Validates firstName and lastName
+        Return: boolean (true if valid, false if not)
+        */
+        //setErrorMessages({...errorMessagesInitial});
+        if (firstName === "") {
+            setNameError("Please enter your first name");
+            return false;
+        } 
+        setNameError("");
+        return true;
     }
 
-    const validatePhoneNumber = (): null | Object => {
+    const validateLastName = (lastName: string): boolean => {
+        /*
+        Desc: Validates firstName and lastName
+        Return: boolean (true if valid, false if not)
+        */
+        //setErrorMessages({...errorMessagesInitial});
+        if (lastName === "") {
+            setNameError("Please enter your last name");
+            return false;
+        } 
+        setNameError("");
+        return true;
+    }
+
+    const validatePhoneNumber = (phoneNumber: string): boolean => {
         /*
         Desc: Validates phone number
         Return: boolean (true if valid, false if not)
         */
+        debugger;
         if (phoneNumber === "") {
-            setErrorMessages({...errorMessages, phoneNumber: "Please enter a phone number"});
+            setPhoneNumberError("Please enter a phone number");
             return false;
         }
+        if(!processPhoneNumber(phoneNumber)) {
+            return false;
+        }
+        setPhoneNumberError("");
         return true;
     }
 
-    const validateEmail = (): null | Object => {
+    const validateEmail = (email: string): boolean => {
         /*
         Desc: Validates email
         Return: boolean (true if valid, false if not)
         */
         if (email === "") {
-            return {email: "Please enter your email"};
-
+            setEmailError("Please enter your email");
+            return false;
         }
         else if (!email.includes("@")) {
-            return {email: "Please enter a valid email address"};
+            setEmailError("Please enter a valid email address");
+            return false;
         }
         //else if (check if email already exists)
         //alert("Account with this email already exists") 
-        return null;
+        setEmailError("");
+        return true;
     }
 
-    const validatePassword = (): null | Object => {
+    const validatePassword = (password: { value: string; }): boolean => {
         /*
         Desc: Validates password
         Return: boolean (true if valid, false if not)
         */
         const MIN_PASSWORD_LENGTH = 6;
         if (password.value === "") {
-            return {password: "Please enter a password"};
+            setPasswordError("Please enter a password");
+            return false;
         }
         else if (password.value.length < MIN_PASSWORD_LENGTH) {
-            return {password:  `Please choose a password at least ${MIN_PASSWORD_LENGTH} characters long`};
+            setPasswordError(`Please choose a password at least ${MIN_PASSWORD_LENGTH} characters long`);
+            return false;
         }
-        return null;
+        setPasswordError("");
+        return true;
     }
 
-    function processPhoneNumber(): null | Object {
+    function processPhoneNumber(phoneNumber: string): boolean {
         /*
         Desc: Converts phoneNumber string to number. Saves it in global variable processedPhoneNumber
         Return: boolean (true if number successfuly processed, false if not)
@@ -218,17 +251,18 @@ const CreateAccountPage = (): JSX.Element => {
         try {
             const processedString = phoneNumber.replace(/[^0-9]/g, "");
             if (processedString === "") {
-                return { phoneNumber: "Please enter your phone number in the form XXX-XXX-XXXX"};
+                setPhoneNumberError("Please enter your phone number in the form XXX-XXX-XXXX");
+                return false;
             }
             // processedPhoneNumber = parseInt(processedString);
             setPhoneNumber(processedString);
-
         }
         catch (error) {
             console.error(error);
-            return {phoneNumber: "Sorry there was an error processing your phone number. Please enter it in the form XXX-XXX-XXXX"};
+            setPhoneNumberError("Sorry there was an error processing your phone number. Please enter it in the form XXX-XXX-XXXX");
+            return false;
         }
-        return false;
+        return true;
     }
 
     function checkError(type: string) {
@@ -245,54 +279,72 @@ const CreateAccountPage = (): JSX.Element => {
                     {/*Div for the user type section*/}
                     <div id="accountTypeBox">
                         <p id="userTypeLabel"> I am a </p>
-                        <div className="accountLabel">
+                        <div className="accountLabel" >
                             <input type="radio"
                                 className="userTypeButton"
                                 value="donor" //Specifies the value for the useState
                                 name="userType" //connects all options under group "userType" -> only one can be selected at a time
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setUserType(e.target.value)} />donor
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    setUserType(e.target.value);
+                                    validateUserType(e.target.value);
+                                }} />donor
 
                             <input type="radio"
                                 className="userTypeButton"
                                 value="volunteer"
                                 name="userType"
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setUserType(e.target.value)} />volunteer
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    setUserType(e.target.value);
+                                    validateUserType(e.target.value);
+                                }} />volunteer
 
                             <input type="radio"
                                 className="userTypeButton"
                                 value="administrator"
                                 name="userType"
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setUserType(e.target.value)} />administrator
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    setUserType(e.target.value);
+                                    validateUserType(e.target.value);
+                                }} />administrator
                         </div>
                     </div>
-                    <div className="inputError">{errorMessages.userType}</div>
+                    <div className="inputError">{userTypeError}</div>
 
                     <div id="nameBox">
                         <div className="labelInputBox" id="firstNameBox">
                             <p className="formLabel">First Name</p>
                             <input className="inputBox"
                                 type="text"
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setFirstName(e.target.value)}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    setFirstName(e.target.value);
+                                    validateFirstName(e.target.value);
+                                }}
                             />
                         </div>
                         <div className="labelInputBox" id="lastNameBox">
                             <p className="formLabel">Last Name</p>
                             <input className="inputBox"
                                 type="text"
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setLastName(e.target.value)}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    setLastName(e.target.value);
+                                    validateLastName(e.target.value);
+                                }}
                             />
                         </div>
                     </div>
-                    <div className="inputError">{errorMessages.name}</div>
+                    <div className="inputError">{nameError}</div>
 
                     <div className="labelInputBox">
                         <p className="formLabel">Email</p>
                         <input className="inputBox"
                             type="text"
                             autoComplete="email"
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                setEmail(e.target.value);
+                                validateEmail(e.target.value);
+                            }}
                         />
-                        <div className="inputError">{errorMessages.email}</div>
+                        <div className="inputError">{emailError}</div>
                     </div>
 
                     <div className="labelInputBox">
@@ -300,9 +352,12 @@ const CreateAccountPage = (): JSX.Element => {
                         <input className="inputBox"
                             type="text"
                             autoComplete="phone"
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPhoneNumber(e.target.value)}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                setPhoneNumber(e.target.value);
+                                validatePhoneNumber(e.target.value);
+                            }}
                         />
-                        <div className="inputError">{errorMessages.phoneNumber}</div>
+                        <div className="inputError">{phoneNumberError}</div>
                     </div>
 
                     <div className="labelInputBox">
@@ -312,7 +367,10 @@ const CreateAccountPage = (): JSX.Element => {
                             value={password.value}
                             type={password.showPassword ? "text" : "password"}
                             disableUnderline={true}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword({ ...password, "value": e.target.value })}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                setPassword({ ...password, "value": e.target.value });
+                                validatePassword({ ...password, "value": e.target.value });
+                            }}
                             endAdornment={
                                 <InputAdornment position="end">
                                     <IconButton
@@ -324,7 +382,7 @@ const CreateAccountPage = (): JSX.Element => {
                                 </InputAdornment>
                             }
                         />
-                        <div className="inputError">{errorMessages.password}</div>
+                        <div className="inputError">{passwordError}</div>
                     </div>
 
                 </form>

--- a/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
+++ b/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
@@ -153,7 +153,6 @@ const CreateAccountPage = (): JSX.Element => {
         Return: boolean (true if valid, false if not)
         */
         //setErrorMessages({...errorMessagesInitial});
-        debugger;
         if (validateFirstName(firstName) && validateLastName(lastName)) {
             return true;
         } else if (!validateFirstName(firstName) && !validateLastName(lastName)) {
@@ -194,7 +193,6 @@ const CreateAccountPage = (): JSX.Element => {
         Desc: Validates phone number
         Return: boolean (true if valid, false if not)
         */
-        debugger;
         if (phoneNumber === "") {
             setPhoneNumberError("Please enter a phone number");
             return false;

--- a/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
+++ b/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
@@ -85,12 +85,9 @@ const CreateAccountPage = (): JSX.Element => {
         }).catch(
             error => {
                 const code = error.code;
-                debugger;
-                console.log(error);
                 setPasswordError(error.message);
                 switch (code) {
                     case 'UsernameExistsException':
-                        //alert("Account already exists");
                         return false;
                 }
             }
@@ -219,8 +216,6 @@ const CreateAccountPage = (): JSX.Element => {
             setEmailError("Please enter a valid email address");
             return false;
         }
-        //else if (check if email already exists)
-        //alert("Account with this email already exists") 
         setEmailError("");
         return true;
     }

--- a/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
+++ b/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
@@ -88,10 +88,7 @@ const CreateAccountPage = (): JSX.Element => {
             error => {
                 const code = error.code;
                 setPasswordError(error.message);
-                switch (code) {
-                    case 'UsernameExistsException':
-                        return false;
-                }
+                return false;
             }
         );
         return response;
@@ -104,9 +101,9 @@ const CreateAccountPage = (): JSX.Element => {
         */
         // let userAuth = await Auth.currentUserInfo();
         // console.log(userAuth);
-        let userAuth2 = await Auth.currentAuthenticatedUser();
-        console.log(userAuth2.username);
-        console.log(id);
+        // let userAuth2 = await Auth.currentAuthenticatedUser();
+        // console.log(userAuth2.username);
+        // console.log(id);
 
         const accountData = {
             userType: userType,

--- a/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
+++ b/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
@@ -129,10 +129,10 @@ const CreateAccountPage = (): JSX.Element => {
         */
         let currentErrors = {};
         currentErrors = validateUserType() ? {...currentErrors, ...validateUserType()} : currentErrors;
-        currentErrors = validateFirstName() ? {...currentErrors, ...validateFirstName()} : currentErrors;
-        currentErrors = validateLastName() ? {...currentErrors, ...validateLastName()} : currentErrors;
+        currentErrors = validateName() ? {...currentErrors, ...validateName()} : currentErrors;
         currentErrors = validateEmail() ? {...currentErrors, ...validateEmail()} : currentErrors;
         currentErrors = validatePhoneNumber() ? {...currentErrors, ...validatePhoneNumber()} : currentErrors;
+        currentErrors = processPhoneNumber() ? {...currentErrors, ...processPhoneNumber()} : currentErrors;
         currentErrors = validatePassword() ? {...currentErrors, ...validatePassword()} : currentErrors;
         setErrorMessages({...errorMessagesInitial, ...currentErrors});
         return Object.keys(currentErrors).length === 0;
@@ -149,33 +149,34 @@ const CreateAccountPage = (): JSX.Element => {
         return null;
     }
 
-    const validateFirstName = (): null | Object => {
+    const validateName = (): null | Object => {
         /*
-        Desc: Validates firstName
+        Desc: Validates firstName and lastName
         Return: boolean (true if valid, false if not)
         */
         //setErrorMessages({...errorMessagesInitial});
+        
         if (firstName === "" && lastName === "") {
             return{name: "Please enter your full name"};
         } else if (firstName === "") {
             return{name: "Please enter your first name"};
-        }
-        return{name: ""};
-    }
-    const validateLastName = (): null | Object => {
-        /*
-        Desc: Validates lastName
-        Return: boolean (true if valid, false if not)
-        */
-        //setErrorMessages({...errorMessagesInitial});
-        if (firstName === "" && lastName === "") {
-            return{name: "Please enter your full name"};
         } else if (lastName === "") {
             return{name: "Please enter your last name"};
         }
-        return{name: ""};
+        return null;
     }
 
+    const validatePhoneNumber = (): null | Object => {
+        /*
+        Desc: Validates phone number
+        Return: boolean (true if valid, false if not)
+        */
+        if (phoneNumber === "") {
+            setErrorMessages({...errorMessages, phoneNumber: "Please enter a phone number"});
+            return false;
+        }
+        return true;
+    }
 
     const validateEmail = (): null | Object => {
         /*
@@ -184,13 +185,14 @@ const CreateAccountPage = (): JSX.Element => {
         */
         if (email === "") {
             return {email: "Please enter your email"};
+
         }
         else if (!email.includes("@")) {
             return {email: "Please enter a valid email address"};
         }
         //else if (check if email already exists)
         //alert("Account with this email already exists") 
-        return{email: ""};
+        return null;
     }
 
     const validatePassword = (): null | Object => {
@@ -205,10 +207,10 @@ const CreateAccountPage = (): JSX.Element => {
         else if (password.value.length < MIN_PASSWORD_LENGTH) {
             return {password:  `Please choose a password at least ${MIN_PASSWORD_LENGTH} characters long`};
         }
-        return{password: ""};
+        return null;
     }
 
-    function validatePhoneNumber(): null | Object {
+    function processPhoneNumber(): null | Object {
         /*
         Desc: Converts phoneNumber string to number. Saves it in global variable processedPhoneNumber
         Return: boolean (true if number successfuly processed, false if not)
@@ -226,7 +228,7 @@ const CreateAccountPage = (): JSX.Element => {
             console.error(error);
             return {phoneNumber: "Sorry there was an error processing your phone number. Please enter it in the form XXX-XXX-XXXX"};
         }
-        return{phoneNumber: ""};
+        return false;
     }
 
     function checkError(type: string) {
@@ -270,20 +272,14 @@ const CreateAccountPage = (): JSX.Element => {
                             <p className="formLabel">First Name</p>
                             <input className="inputBox"
                                 type="text"
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                    setFirstName(e.target.value);
-                                    setErrorMessages({...errorMessages, ...validateFirstName()});
-                                }}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setFirstName(e.target.value)}
                             />
                         </div>
                         <div className="labelInputBox" id="lastNameBox">
                             <p className="formLabel">Last Name</p>
                             <input className="inputBox"
                                 type="text"
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                    setLastName(e.target.value);
-                                    setErrorMessages({...errorMessages, ...validateLastName()});
-                                }}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setLastName(e.target.value)}
                             />
                         </div>
                     </div>
@@ -294,10 +290,7 @@ const CreateAccountPage = (): JSX.Element => {
                         <input className="inputBox"
                             type="text"
                             autoComplete="email"
-                            onInput={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                setEmail(e.target.value);
-                                setErrorMessages({...errorMessages, ...validateEmail()});
-                            }}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
                         />
                         <div className="inputError">{errorMessages.email}</div>
                     </div>
@@ -307,10 +300,7 @@ const CreateAccountPage = (): JSX.Element => {
                         <input className="inputBox"
                             type="text"
                             autoComplete="phone"
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                setPhoneNumber(e.target.value);
-                                setErrorMessages({...errorMessages, ...validatePhoneNumber()});
-                            }}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPhoneNumber(e.target.value)}
                         />
                         <div className="inputError">{errorMessages.phoneNumber}</div>
                     </div>
@@ -322,10 +312,7 @@ const CreateAccountPage = (): JSX.Element => {
                             value={password.value}
                             type={password.showPassword ? "text" : "password"}
                             disableUnderline={true}
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                setPassword({ ...password, "value": e.target.value });
-                                setErrorMessages({...errorMessages, ...validatePassword()});
-                            }}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword({ ...password, "value": e.target.value })}
                             endAdornment={
                                 <InputAdornment position="end">
                                     <IconButton

--- a/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
+++ b/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
@@ -152,11 +152,14 @@ const CreateAccountPage = (): JSX.Element => {
         Return: boolean (true if valid, false if not)
         */
         //setErrorMessages({...errorMessagesInitial});
+        debugger;
+        if (!validateFirstName(firstName) && !validateLastName(lastName)) {
+            setNameError("Please enter your full name");
+            return false;
+        }
         if (validateFirstName(firstName) && validateLastName(lastName)) {
             return true;
-        } else if (!validateFirstName(firstName) && !validateLastName(lastName)) {
-            setNameError("Please enter your full name");
-        }
+        } 
         return false;
     }
     const validateFirstName = (firstName: string): boolean => {

--- a/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
+++ b/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
@@ -7,6 +7,8 @@ import VisibilityOffIcon from '@mui/icons-material/VisibilityOffOutlined';
 import InputAdornment from '@mui/material/InputAdornment';
 import Input from '@mui/material/Input';
 import IconButton from '@mui/material/IconButton';
+import isEmail from 'validator/lib/isEmail';
+import isMobilePhone from 'validator/lib/isMobilePhone';
 import { v4 as uuidv4 } from 'uuid';
 /* Backend */
 import { addUser, User } from 'api/user';
@@ -152,7 +154,6 @@ const CreateAccountPage = (): JSX.Element => {
         Return: boolean (true if valid, false if not)
         */
         //setErrorMessages({...errorMessagesInitial});
-        debugger;
         if (!validateFirstName(firstName) && !validateLastName(lastName)) {
             setNameError("Please enter your full name");
             return false;
@@ -215,7 +216,7 @@ const CreateAccountPage = (): JSX.Element => {
             setEmailError("Please enter your email");
             return false;
         }
-        else if (!email.includes("@")) {
+        else if (!isEmail(email)) {
             setEmailError("Please enter a valid email address");
             return false;
         }
@@ -228,7 +229,7 @@ const CreateAccountPage = (): JSX.Element => {
         Desc: Validates password
         Return: boolean (true if valid, false if not)
         */
-        const MIN_PASSWORD_LENGTH = 6;
+        const MIN_PASSWORD_LENGTH = 8;
         if (password.value === "") {
             setPasswordError("Please enter a password");
             return false;
@@ -248,7 +249,7 @@ const CreateAccountPage = (): JSX.Element => {
         */
         try {
             const processedString = phoneNumber.replace(/[^0-9]/g, "");
-            if (processedString === "") {
+            if (!isMobilePhone(processedString)) {
                 setPhoneNumberError("Please enter your phone number in the form XXX-XXX-XXXX");
                 return false;
             }

--- a/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
+++ b/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
@@ -85,10 +85,12 @@ const CreateAccountPage = (): JSX.Element => {
         }).catch(
             error => {
                 const code = error.code;
+                debugger;
                 console.log(error);
+                setPasswordError(error.message);
                 switch (code) {
                     case 'UsernameExistsException':
-                        alert("Account already exists");
+                        //alert("Account already exists");
                         return false;
                 }
             }

--- a/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
+++ b/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
@@ -249,7 +249,7 @@ const CreateAccountPage = (): JSX.Element => {
         */
         try {
             const processedString = phoneNumber.replace(/[^0-9]/g, "");
-            if (!isMobilePhone(processedString)) {
+            if (!isMobilePhone(processedString, "en-US")) {
                 setPhoneNumberError("Please enter your phone number in the form XXX-XXX-XXXX");
                 return false;
             }

--- a/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
+++ b/frontend/src/components/authentication/CreateAccountPage/CreateAccountPage.tsx
@@ -168,7 +168,7 @@ const CreateAccountPage = (): JSX.Element => {
         Return: boolean (true if valid, false if not)
         */
         //setErrorMessages({...errorMessagesInitial});
-        if (firstName === "") {
+        if (firstName.match("\\s+")) {
             setNameError("Please enter your first name");
             return false;
         } 
@@ -182,7 +182,7 @@ const CreateAccountPage = (): JSX.Element => {
         Return: boolean (true if valid, false if not)
         */
         //setErrorMessages({...errorMessagesInitial});
-        if (lastName === "") {
+        if (lastName.match("\\s+")) {
             setNameError("Please enter your last name");
             return false;
         } 

--- a/frontend/src/components/authentication/LoginPage/LoginPage.css
+++ b/frontend/src/components/authentication/LoginPage/LoginPage.css
@@ -32,6 +32,11 @@
     padding: 2%;
 }
 
+.inputError {
+    text-align: left;
+    color: var(--red);
+}
+
 #passwordBox {
     font-family: inherit;
 }

--- a/frontend/src/components/authentication/LoginPage/LoginPage.tsx
+++ b/frontend/src/components/authentication/LoginPage/LoginPage.tsx
@@ -18,6 +18,8 @@ const LoginPage = (): JSX.Element => {
         value: "",
         showPassword: false
     });
+    const [emailError, setEmailError] = useState<string>("");
+    const [passwordError, setPasswordError] = useState<string>("");
     let navigate = useNavigate();
 
     const forgotPasswordPath = "/ForgotPassword";
@@ -30,13 +32,13 @@ const LoginPage = (): JSX.Element => {
                 const code = error.code;
                 switch (code) {
                     case 'NotAuthorizedException':
-                        alert("Please enter valid credentials");
+                        setPasswordError("Please enter valid credentials");
                         return false;
                     case 'UserNotFoundException':
-                        alert("User does not exist");
+                        setPasswordError("User does not exist");
                         return false;
                     default:
-                        alert(error);
+                        setPasswordError(error);
                         return false;
                 }
             }
@@ -44,13 +46,14 @@ const LoginPage = (): JSX.Element => {
         return response;
     }
 
-
     const login = async (e: React.MouseEvent<HTMLButtonElement>): Promise<any> => {
         e.preventDefault();
         let valid = checkCredentials();
-        let checkAWS = await awsLogin();
-        if (checkAWS && valid) {
-            navigate("/Donor");
+        if (valid) {
+            let checkAWS = await awsLogin();
+            if (checkAWS) {
+                navigate("/Donor");
+            }
         }
         /*
         else if (valid && admin){
@@ -65,16 +68,20 @@ const LoginPage = (): JSX.Element => {
         */
     }
     const checkCredentials = (): boolean => {
+        //reset error messages
+        setEmailError("");
+        setPasswordError("");
+        let noErrors = true;
+
         if (email === "") {
-            alert("Email is blank. Please try again.")
-            return false;
-        } else if (password.value === "") {
-            alert("Password is blank. Please try again.");
-            return false;
+            setEmailError("Please enter an email");
+            noErrors = false;
+        } 
+        if (password.value === "") {
+            setPasswordError("Please enter your password");
+            noErrors = false;
         } // check other invalid errors
-        else {
-            return true;
-        }
+        return noErrors;
         // if no errors/valid login -> redirect to logged in page
     }
 
@@ -88,6 +95,7 @@ const LoginPage = (): JSX.Element => {
                     type="text"
                     onChange={(event: React.ChangeEvent<HTMLInputElement>) => setEmail(event?.target?.value)}
                 />
+                <div className="inputError">{emailError}</div>
                 <div id="loginPassword">
                     <p className="loginLabel">Password</p>
                     <Link to={forgotPasswordPath} id="loginForgotPassword">Forgot Password?</Link>
@@ -110,7 +118,8 @@ const LoginPage = (): JSX.Element => {
                         </InputAdornment>
                     }
                 />
-                <button type="button" id="loginSubmit" onClick={login}>Log In</button>
+                <div className="inputError">{passwordError}</div>
+                <button type="button" id="loginSubmit" onClick={login} >Log In</button>
             </form>
             <div style={{ textAlign: "right", marginTop: "10px" }}>
                 <p className="loginCreateAccount">Don't have an account? </p>

--- a/frontend/src/components/authentication/NewPasswordPage/NewPasswordPage.css
+++ b/frontend/src/components/authentication/NewPasswordPage/NewPasswordPage.css
@@ -32,11 +32,7 @@
     height: 0.9em;
 }
 
-#userTypeLabel {
-    margin: 0px 0px 0px 0px;
-    font-weight: bold;
-    font-size: 16px;
-}
+
 
 .accountLabel {
     color: var(--secondary);
@@ -44,14 +40,6 @@
     align-content: center;
 }
 
-.userTypeButton {
-    filter: grayscale();
-    margin: 2px 9px 0px 26px; 
-}
-
-.userTypeButton:hover {
-    cursor: pointer;
-}
 
 #nameBox {
     display: flex;
@@ -151,15 +139,7 @@
 }
 
 @media only screen and (max-height: 800px) {
-    #createAccountBox {
-        width: 415px;
-        height: 546px;
 
-        margin: auto;
-        margin-top: 50vh;
-        transform: translateY(-50%);
-        padding: 36px 50px 49px 50px;
-    }
 
     #createAccountText {
         font-size: 25px;
@@ -167,9 +147,6 @@
         margin: 0px 0px 24px 0px;
     }
     
-    #accountTypeBox {
-        margin: 0px 0px 3px 0px;
-    }
     
     #userTypeLabel {
         margin: 0px 0px 0px 0px;
@@ -180,9 +157,6 @@
         font-size: 10px;
     }
     
-    .userTypeButton {
-        margin: 1px 6px 0px 18px; 
-    }
     
     #firstNameBox {
         width: 138px;
@@ -225,15 +199,6 @@
 }
 
 @media only screen and (max-width: 700px) {
-    #createAccountBox {
-        width: 405px;
-        height: 546px;
-
-        margin: auto;
-        margin-top: 50vh;
-        transform: translateY(-50%);
-        padding: 36px 44px 49px 44px;
-    }
 
     #createAccountText {
         font-size: 25px;
@@ -241,9 +206,7 @@
         margin: 0px 0px 24px 0px;
     }
     
-    #accountTypeBox {
-        margin: 0px 0px 3px 0px;
-    }
+
     
     #userTypeLabel {
         margin: 0px 0px 0px 0px;
@@ -254,9 +217,6 @@
         font-size: 10px;
     }
     
-    .userTypeButton {
-        margin: 1px 6px 0px 18px; 
-    }
     
     #firstNameBox {
         width: 138px;
@@ -295,17 +255,5 @@
     
     #logInLink {
         margin: 0px 0px 0px 3px;
-    }
-}
-
-@media only screen and (max-width: 500px) {
-    #createAccountBox {
-        width: 405px;
-        height: 506px;
-
-        margin: auto;
-        margin-top: 50vh;
-        transform: translateY(-50%);
-        padding: 36px 44px 49px 44px;
     }
 }

--- a/frontend/src/components/authentication/VerifyAccountPage/VerifyAccountPage.css
+++ b/frontend/src/components/authentication/VerifyAccountPage/VerifyAccountPage.css
@@ -32,26 +32,12 @@
     height: 0.9em;
 }
 
-#userTypeLabel {
-    margin: 0px 0px 0px 0px;
-    font-weight: bold;
-    font-size: 16px;
-}
-
 .accountLabel {
     color: var(--secondary);
     font-weight: bold;
     align-content: center;
 }
 
-.userTypeButton {
-    filter: grayscale();
-    margin: 2px 9px 0px 26px;
-}
-
-.userTypeButton:hover {
-    cursor: pointer;
-}
 
 #nameBox {
     display: flex;
@@ -164,25 +150,12 @@
 }
 
 @media only screen and (max-height: 800px) {
-    #createAccountBox {
-        width: 415px;
-        height: 546px;
-
-        margin: auto;
-        margin-top: 50vh;
-        transform: translateY(-50%);
-        padding: 36px 50px 49px 50px;
-    }
-
     #createAccountText {
         font-size: 25px;
         line-height: 28px;
         margin: 0px 0px 24px 0px;
     }
 
-    #accountTypeBox {
-        margin: 0px 0px 3px 0px;
-    }
 
     #userTypeLabel {
         margin: 0px 0px 0px 0px;
@@ -193,9 +166,6 @@
         font-size: 10px;
     }
 
-    .userTypeButton {
-        margin: 1px 6px 0px 18px;
-    }
 
     #firstNameBox {
         width: 138px;
@@ -241,15 +211,7 @@
 }
 
 @media only screen and (max-width: 700px) {
-    #createAccountBox {
-        width: 405px;
-        height: 546px;
 
-        margin: auto;
-        margin-top: 50vh;
-        transform: translateY(-50%);
-        padding: 36px 44px 49px 44px;
-    }
 
     #createAccountText {
         font-size: 25px;
@@ -270,9 +232,6 @@
         font-size: 10px;
     }
 
-    .userTypeButton {
-        margin: 1px 6px 0px 18px;
-    }
 
     #firstNameBox {
         width: 138px;
@@ -312,17 +271,5 @@
 
     #logInLink {
         margin: 0px 0px 0px 3px;
-    }
-}
-
-@media only screen and (max-width: 500px) {
-    #createAccountBox {
-        width: 405px;
-        height: 506px;
-
-        margin: auto;
-        margin-top: 50vh;
-        transform: translateY(-50%);
-        padding: 36px 44px 49px 44px;
     }
 }


### PR DESCRIPTION
<p float="left" align="middle">
<img width="360" alt="Screen Shot 2022-08-06 at 11 29 25 AM" src="https://user-images.githubusercontent.com/85770026/183316412-92c80998-85cd-4c19-a1cf-2c05af7e01a3.png">
<img width="360" alt="Screen Shot 2022-08-06 at 11 29 35 AM" src="https://user-images.githubusercontent.com/85770026/183316418-f1afc6b4-8b3d-4fba-8942-212c489e52f0.png">
</p>

- Errors now handled through the screen instead of alert() on login and create account pages.
- AWS errors are being displayed using error.message, i.e. "Password did not conform with policy: Password not long enough." 
- Frontend checks are limited to the most basic ones so far (not empty, has @, only numbers, etc.)