### PR TITLE
fix: support missing donorId for InStore donations

### DIFF
--- a/src/app/Admin/DonationInfo/[[...slug]]/page.tsx
+++ b/src/app/Admin/DonationInfo/[[...slug]]/page.tsx
@@ -311,6 +311,15 @@ function DonationInfoPage() {
           });
       };
       getDonor();
+    } else if (item.scheduling === "InStore") {
+      const nameParts = (item.donorName ?? "").split(" ");
+      setDonor({
+        id: "",
+        firstName: nameParts[0] ?? "",
+        lastName: nameParts.slice(1).join(" ") ?? "",
+        email: item.donorEmail ?? "",
+        phone: item.donorPhone ?? "",
+      });
     }
 
     if (item.timeAvailability) {

--- a/src/components/DonationTable/page.tsx
+++ b/src/components/DonationTable/page.tsx
@@ -46,7 +46,7 @@ export default function DonationsTable({ viewType }: DonationsTableProps): React
   useEffect(() => {
     const fetchDonorNames = async () => {
       const uniqueDonorIds = Array.from(
-        new Set(items.map((item) => item.donorId)),
+        new Set(items.map((item) => item.donorId).filter((id) => id !== "")),
       );
       const map: Record<string, any> = { ...donorInfoMap };
 
@@ -71,8 +71,9 @@ export default function DonationsTable({ viewType }: DonationsTableProps): React
     }
   }, [items]);
 
-  const getDonorName = (id: string) => {
-    const donor = donorInfoMap[id];
+  const getDonorName = (item: Item) => {
+    if (!item.donorId) return item.donorName ?? "Unknown";
+    const donor = donorInfoMap[item.donorId];
     return donor ? `${donor.firstName} ${donor.lastName}` : "Loading...";
   };
 
@@ -145,7 +146,7 @@ export default function DonationsTable({ viewType }: DonationsTableProps): React
                   style={{ textDecoration: "none" }}
                   className="tableRow"
                 >
-                  <TableCell scope="row">{getDonorName(d.donorId)}</TableCell>
+                  <TableCell scope="row">{getDonorName(d)}</TableCell>
                   <TableCell>{d.scheduling}</TableCell>
                   <TableCell>{convertTime(d.timeSubmitted)}</TableCell>
                   <TableCell>{convertTime(d.timeApproved)}</TableCell>

--- a/src/components/admin/DonationDetails/DonationDetails.tsx
+++ b/src/components/admin/DonationDetails/DonationDetails.tsx
@@ -22,7 +22,7 @@ export default function DonationDetails(): React.ReactNode {
 
   useEffect(() => {
     const fetchDonorNames = async () => {
-      const uniqueDonorIds = Array.from(new Set(items.map((item) => item.donorId)));
+      const uniqueDonorIds = Array.from(new Set(items.map((item) => item.donorId).filter((id) => id !== "")));
       const map: Record<string, { firstName: string; lastName: string }> = {};
 
       await Promise.all(
@@ -44,8 +44,9 @@ export default function DonationDetails(): React.ReactNode {
     }
   }, [items]);
 
-  const getDonorName = (id: string) => {
-    const donor = donorInfoMap[id];
+  const getDonorName = (item: Item) => {
+    if (!item.donorId) return item.donorName ?? "Unknown";
+    const donor = donorInfoMap[item.donorId];
     return donor ? `${donor.firstName} ${donor.lastName}` : "Loading...";
   };
 
@@ -96,7 +97,7 @@ export default function DonationDetails(): React.ReactNode {
           </div>
         </div>
 
-        <div>{getDonorName(item.donorId)}</div>
+        <div>{getDonorName(item)}</div>
 
         <div>{moment(item.timeSubmitted).format("MM.DD.YYYY - h:mm A")}</div>
       </div>


### PR DESCRIPTION
## Developer: Sean McCormick

### Pull Request Summary

InStore donations store donor info directly on the item (donorName, donorEmail, donorPhone) since they have no Clerk account and donorId is an empty string. The donation table, donation details, and donation info page all called getClerkUser("") for these donations, causing them to show "Loading..." or blank contact info indefinitely. This fix skips the Clerk lookup when donorId is empty and falls back to the item's InStore fields instead.

### Testing

Tested by creating an InStore donation and verifying the donor name appears correctly in the donation table and contact info is populated on the donation info page.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Ask for a review in communication channels

### Reviewer Checklist - PULL REQUEST REVIEWER ONLY

IMPORTANT: The rest of the sections in this checklist should only be filled out by authorized pull request reviewers. If you are the individual contributor, do not fill out the rest of the fields or check the boxes.

## Reviewer: Full Name

NOTE: Pull requests should only be merged when all boxes are checked.

- [ ] Assign yourself as reviewer if not assigned
- [ ] The reviewer name is specified
- [ ] The code is fully reviewed
- [ ] Meaningful feedback is given
- [ ] Let developer know a review has been made
